### PR TITLE
change git gem installs to use http:// instead of git://

### DIFF
--- a/ruby/ruby18/Gemfile
+++ b/ruby/ruby18/Gemfile
@@ -6,7 +6,7 @@ gem "sinatra"
 ruby "1.8.7"
 
 # Tested: git based gem
-gem "cf", :github => "cloudfoundry/cf", :ref => "9e802c"
+gem "cf", :git => "http://github.com/cloudfoundry/cf.git", :ref => "9e802c"
 
 # Tested: gem native ext
 gem "ffi"

--- a/ruby/ruby18/Gemfile.lock
+++ b/ruby/ruby18/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/cloudfoundry/cf.git
+  remote: http://github.com/cloudfoundry/cf.git
   revision: 9e802c091d87ff08121d8da1cb309ff0e9681ef1
   ref: 9e802c
   specs:

--- a/ruby/ruby19/Gemfile
+++ b/ruby/ruby19/Gemfile
@@ -6,7 +6,7 @@ gem "sinatra"
 # > Do not specify ruby version since it should be 1.9.x by default
 
 # Tested: git based gem
-gem "cf", :github => "cloudfoundry/cf", :ref => "9e802c"
+gem "cf", :git => "http://github.com/cloudfoundry/cf.git", :ref => "9e802c"
 
 # Tested: gem native ext
 gem "ffi"

--- a/ruby/ruby19/Gemfile.lock
+++ b/ruby/ruby19/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/cloudfoundry/cf.git
+  remote: http://github.com/cloudfoundry/cf.git
   revision: 9e802c091d87ff08121d8da1cb309ff0e9681ef1
   ref: 9e802c
   specs:


### PR DESCRIPTION
I couldn't get the git:// urls to work in my firewalled enterprise that requires an http proxy.  This PR changes the git:// url to http so that it can work through a proxy.

This change is testing essentially the same thing as the git:// use case but with http instead.  Arguably a super set of the git:// test.

Yeti PR forthcoming.
